### PR TITLE
feat: include full tile grid in GameStateDTO for client synchronization

### DIFF
--- a/src/main/java/com/arsw/bomberdino/model/dto/response/GameStateDTO.java
+++ b/src/main/java/com/arsw/bomberdino/model/dto/response/GameStateDTO.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * WebSocket broadcast DTO containing complete game state snapshot.
  * Sent every frame (60 FPS) to synchronize all clients.
- * 
+ *
  * @author Mapunix, Rivaceraptos, Yisus-Rex
  * @version 1.0
  * @since 2025-10-26
@@ -24,29 +24,33 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class GameStateDTO {
-    
+
     @NotBlank(message = "Session ID cannot be blank")
     private String sessionId;
-    
+
     @NotNull(message = "Game status cannot be null")
     private GameStatus status;
-    
+
+    @NotNull
+    @Valid
+    private TileDTO[][] tiles;
+
     @NotNull(message = "Players list cannot be null")
     @Valid
     private List<PlayerDTO> players;
-    
+
     @NotNull(message = "Bombs list cannot be null")
     @Valid
     private List<BombDTO> bombs;
-    
+
     @NotNull(message = "Explosions list cannot be null")
     @Valid
     private List<ExplosionDTO> explosions;
-    
+
     @NotNull(message = "Power-ups list cannot be null")
     @Valid
     private List<PowerUpDTO> powerUps;
-    
+
     @NotNull(message = "Server time cannot be null")
     private Long serverTime;
 }

--- a/src/main/java/com/arsw/bomberdino/model/dto/response/TileDTO.java
+++ b/src/main/java/com/arsw/bomberdino/model/dto/response/TileDTO.java
@@ -11,6 +11,10 @@ import lombok.Getter;
 /**
  * Immutable tile snapshot for client rendering.
  * Only contains data required by the frontend to repaint the map.
+ *
+ * @author Mapunix, Rivaceraptos, Yisus-Rex
+ * @version 1.0
+ * @since 2025-10-26
  */
 @Getter
 @Builder

--- a/src/main/java/com/arsw/bomberdino/model/dto/response/TileDTO.java
+++ b/src/main/java/com/arsw/bomberdino/model/dto/response/TileDTO.java
@@ -1,0 +1,28 @@
+package com.arsw.bomberdino.model.dto.response;
+
+import com.arsw.bomberdino.model.enums.TileType;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Immutable tile snapshot for client rendering.
+ * Only contains data required by the frontend to repaint the map.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public final class TileDTO {
+
+  @Min(value = 0, message = "X coordinate must be non-negative")
+  private final int x;
+
+  @Min(value = 0, message = "Y coordinate must be non-negative")
+  private final int y;
+
+  @NotNull(message = "Tile type cannot be null")
+  private final TileType type;
+}

--- a/src/main/java/com/arsw/bomberdino/model/entity/GameMap.java
+++ b/src/main/java/com/arsw/bomberdino/model/entity/GameMap.java
@@ -78,7 +78,7 @@ public class GameMap {
 
     /**
      * Gets spawn points that are currently unoccupied.
-     * 
+     *
      * @return list of available spawn Point instances
      */
     public List<Point> getAvailableSpawnPoints() {
@@ -92,7 +92,7 @@ public class GameMap {
 
     /**
      * Finds all empty tiles suitable for power-up spawning.
-     * 
+     *
      * @return list of unoccupied empty tile positions
      */
     public List<Point> getEmptyTilePositions() {
@@ -109,4 +109,5 @@ public class GameMap {
 
         return emptyPositions;
     }
+
 }

--- a/src/main/java/com/arsw/bomberdino/model/entity/GameSession.java
+++ b/src/main/java/com/arsw/bomberdino/model/entity/GameSession.java
@@ -6,6 +6,7 @@ import com.arsw.bomberdino.model.dto.response.PointDTO;
 import com.arsw.bomberdino.model.dto.response.GameStateDTO;
 import com.arsw.bomberdino.model.dto.response.PlayerDTO;
 import com.arsw.bomberdino.model.dto.response.PowerUpDTO;
+import com.arsw.bomberdino.model.dto.response.TileDTO;
 import com.arsw.bomberdino.model.enums.GameStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -185,6 +186,7 @@ public class GameSession {
             return GameStateDTO.builder()
                     .sessionId(sessionId.toString())
                     .status(status)
+                    .tiles(mapTilesToDTO())
                     .players(mapPlayersToDTO())
                     .bombs(mapBombsToDTO())
                     .explosions(mapExplosionsToDTO())
@@ -194,6 +196,25 @@ public class GameSession {
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    private TileDTO[][] mapTilesToDTO() {
+        Tile[][] tiles = map.getTiles();
+        int height = tiles.length;
+        int width = height > 0 ? tiles[0].length : 0;
+
+        TileDTO[][] out = new TileDTO[height][width];
+        for (int y = 0; y < height; y++) {
+            Tile[] row = tiles[y];
+            for (int x = 0; x < width; x++) {
+                out[y][x] = TileDTO.builder()
+                        .x(x)
+                        .y(y)
+                        .type(row[x].getType())
+                        .build();
+            }
+        }
+        return out;
     }
 
     private List<PlayerDTO> mapPlayersToDTO() {

--- a/src/main/java/com/arsw/bomberdino/model/enums/TileType.java
+++ b/src/main/java/com/arsw/bomberdino/model/enums/TileType.java
@@ -5,55 +5,59 @@ import lombok.Getter;
 /**
  * Types of tiles that compose the game map.
  * Defines traversability, destructibility, and spawning rules.
- * 
+ *
  * @author Mapunix, Rivaceraptos, Yisus-Rex
  * @version 1.0
  * @since 2025-10-26
  */
 @Getter
 public enum TileType {
-    
+
     EMPTY("Empty", true, false),
     SOLID_WALL("Solid Wall", false, false),
     DESTRUCTIBLE_WALL("Destructible Wall", false, true),
     SPAWN_POINT("Spawn Point", true, false);
-    
+
     private final String displayName;
     private final boolean walkable;
     private final boolean destructible;
-    
+
     TileType(String displayName, boolean walkable, boolean destructible) {
         this.displayName = displayName;
         this.walkable = walkable;
         this.destructible = destructible;
     }
-    
+
     /**
      * Checks if players can walk on this tile type.
+     * 
      * @return true if tile is walkable
      */
     public boolean isWalkable() {
         return walkable;
     }
-    
+
     /**
      * Checks if this tile can be destroyed by explosions.
+     * 
      * @return true if tile is destructible
      */
     public boolean isDestructible() {
         return destructible;
     }
-    
+
     /**
-     * Checks if power-ups can spawn on this tile type. 
+     * Checks if power-ups can spawn on this tile type.
+     * 
      * @return true if tile type is EMPTY
      */
     public boolean canSpawnPowerUp() {
         return this == EMPTY;
     }
-    
+
     /**
      * Checks if explosions can propagate through this tile.
+     * 
      * @return true if tile is not a solid wall
      */
     public boolean allowsExplosion() {


### PR DESCRIPTION
### **Summary**

This PR adds the **map representation** to the game state sent to clients, ensuring all players remain visually synchronized with the server’s authoritative state.

### **Changes**

* **Added** `TileDTO` class for lightweight and immutable tile representation (`x`, `y`, `type` only).
* **Updated** `GameStateDTO` to include a new field:

  ```java
  @NotNull @Valid private TileDTO[][] tiles;
  ```

  This field holds the full 2D tile grid of the current game map.
* **Implemented** `mapTilesToDTO()` in `GameRoom` to convert the internal `Tile[][]` map into a `TileDTO[][]`.
* **Integrated** the tile grid mapping into the game state builder (e.g., `.tiles(mapTilesToDTO())`).
* **Ensured thread-safety** by performing the conversion under read lock while avoiding any reference to the mutable map array.

### **Purpose**

This feature simplifies the frontend rendering logic by sending the entire map state within each game update.
Although this approach is less bandwidth-efficient, it guarantees **synchronization and consistency** between all clients in this initial version.

### **Notes**

* Future optimization: send **partial updates (deltas)** once synchronization and rendering are stable.
* `TileDTO` remains minimal and immutable, following clean architecture principles.